### PR TITLE
Bugfix: measure.find_contours()

### DIFF
--- a/python/coco_json_utils.py
+++ b/python/coco_json_utils.py
@@ -154,6 +154,7 @@ class AnnotationJsonUtils():
             annotation['id'] = self._next_annotation_id()
 
             # Find contours in the isolated mask
+            mask = np.asarray(mask, dtype=np.float32)
             contours = measure.find_contours(mask, 0.5, positive_orientation='low')
 
             polygons = []


### PR DESCRIPTION
- With some configurations, measure.find_contours gives an error message unless the mask image is converted to a numpy array first